### PR TITLE
chore(deps): bump 5 outdated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 certifi==2025.1.31
 fastapi==0.121.2
-langchain==1.0.7
-langchain-openai==1.0.3
+langchain==1.2.17
+langchain-openai==1.2.1
 langchain-google-genai==3.0.3
 langchain-community==0.4.1
-pymongo==4.15.4
-reportlab==4.4.5
-tavily-python==0.7.13
+pymongo==4.17.0
+reportlab==4.5.0
+tavily-python==0.7.24
 uvicorn[standard]==0.38.0
 python-dotenv==1.2.1


### PR DESCRIPTION
## Summary
Updates 5 pinned dependencies to their latest released versions: `langchain` 1.0.7->1.2.17, `langchain-openai` 1.0.3->1.2.1, `pymongo` 4.15.4->4.17.0, `reportlab` 4.4.5->4.5.0, `tavily-python` 0.7.13->0.7.24.

## Why it matters
Keeping pinned dependencies current reduces exposure to known CVEs and ensures compatibility with downstream packages.

## Testing
Registry versions were checked first. The submission flow must also pass repo-local verification before opening this PR.