### PR TITLE
Fix setup repository links

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -115,8 +115,8 @@ La forma más sencilla de comenzar es utilizando el script de instalación, que 
 
 1. Clonar el repositorio:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. Hacer que el script de instalación sea ejecutable y ejecutarlo:
@@ -153,8 +153,8 @@ Si prefieres realizar la instalación manualmente, sigue estos pasos:
 
 1. Clonar el repositorio:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. Instalar dependencias de backend:
@@ -220,8 +220,8 @@ La aplicación puede ejecutarse utilizando Docker y Docker Compose:
 
 1. Clonar el repositorio:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. **Configurar Variables de Entorno**:

--- a/README.fr.md
+++ b/README.fr.md
@@ -116,8 +116,8 @@ La façon la plus simple de commencer est d'utiliser le script de configuration,
 
 1. Clonez le dépôt :
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. Rendez le script de configuration exécutable et lancez-le :
@@ -156,8 +156,8 @@ Si vous préférez configurer manuellement, suivez ces étapes :
 1. Clonez le dépôt :
 
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. Installez les dépendances backend :
@@ -226,8 +226,8 @@ L'application peut être exécutée à l'aide de Docker et Docker Compose :
 1. Clonez le dépôt :
 
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. **Configuration des Variables d'Environnement** :

--- a/README.jp.md
+++ b/README.jp.md
@@ -116,8 +116,8 @@ https://github.com/user-attachments/assets/0e373146-26a7-4391-b973-224ded3182a9
 
 1. リポジトリをクローン：
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. セットアップスクリプトを実行可能にして実行：
@@ -154,8 +154,8 @@ chmod +x setup.sh
 
 1. リポジトリをクローン：
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. バックエンド依存関係をインストール：
@@ -221,8 +221,8 @@ VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
 1. リポジトリをクローン：
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. **環境変数の設定**：

--- a/README.kr.md
+++ b/README.kr.md
@@ -116,8 +116,8 @@ https://github.com/user-attachments/assets/0e373146-26a7-4391-b973-224ded3182a9
 
 1. 저장소 클론:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. 설정 스크립트를 실행 가능하게 만들고 실행:
@@ -154,8 +154,8 @@ chmod +x setup.sh
 
 1. 저장소 클론:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. 백엔드 종속성 설치:
@@ -221,8 +221,8 @@ VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
 1. 저장소 클론:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. **환경 변수 설정**:

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ The easiest way to get started is using the setup script, which automatically de
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. Make the setup script executable and run it:
@@ -154,8 +154,8 @@ If you prefer to set up manually, follow these steps:
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. Install backend dependencies:
@@ -221,8 +221,8 @@ The application can be run using Docker and Docker Compose:
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. **Set up Environment Variables**:

--- a/README.zh.md
+++ b/README.zh.md
@@ -116,8 +116,8 @@ https://github.com/user-attachments/assets/071aa491-009b-4d76-a698-88863149e71c
 
 1. 克隆仓库：
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. 使安装脚本可执行并运行：
@@ -154,8 +154,8 @@ chmod +x setup.sh
 
 1. 克隆仓库：
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. 安装后端依赖：
@@ -221,8 +221,8 @@ VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
 1. 克隆仓库：
 ```bash
-git clone https://github.com/guy-hartstein/tavily-company-research.git
-cd tavily-company-research
+git clone https://github.com/guy-hartstein/company-research-agent.git
+cd company-research-agent
 ```
 
 2. **设置环境变量**：

--- a/setup.sh
+++ b/setup.sh
@@ -239,5 +239,5 @@ fi
 
 echo -e "\n${BOLD}Need help?${NC}"
 echo "- Documentation: README.md"
-echo "- Issues: https://github.com/guy-hartstein/tavily-company-research/issues"
+echo "- Issues: https://github.com/guy-hartstein/company-research-agent/issues"
 echo -e "\n${GREEN}Happy researching! 🚀${NC}"


### PR DESCRIPTION
## Summary
- update setup clone commands across all README translations to use `guy-hartstein/company-research-agent`
- update the setup script help link to the current repository's issues page

Fixes #58.

## Validation
- `rg -n "guy-hartstein/tavily-company-research|cd tavily-company-research" -g "README*.md" -g "setup.sh" .` returns no matches
- inspected the diff to confirm only repository setup links were changed
